### PR TITLE
Change to ESM pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,25 +1,14 @@
 {
   "name": "next-view-transitions",
   "version": "0.1.0",
+  "type": "module",
   "description": "View Transitions API for Next.js App Router",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.mjs",
-  "types": "./dist/cjs/index.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./dist/es/index.d.mts",
-        "default": "./dist/es/index.mjs"
-      },
-      "require": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
-      }
-    }
-  },
+  "exports": "./dist/index.js",
   "scripts": {
     "build": "bunchee",
     "dev": "bunchee --watch"


### PR DESCRIPTION
Mark as ESM package, as next.js already supports ESM pretty well and this will simplify output/types configs a lot.
