### PR TITLE
Add full support for next/link features

### DIFF
--- a/src/link.tsx
+++ b/src/link.tsx
@@ -44,40 +44,31 @@ export function Link(props: React.ComponentProps<typeof NextLink>) {
   const { href, as, replace, scroll } = props
   const onClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>) => {
-      if (shouldPreserveDefault(e)) {
-        return
-      }
-
       if (props.onClick) {
         props.onClick(e)
       }
 
-      e.preventDefault()
-
-      // extended from https://github.com/vercel/next.js/blob/66f8ffaa7a834f6591a12517618dce1fd69784f6/packages/next/src/client/link.tsx#L221-L235
-      // removed the need for pages router support
-      const navigate = () => {
-        router[replace ? 'replace' : 'push'](as || href, {
-          scroll: scroll ?? true,
-        })
+      if (shouldPreserveDefault(e)) {
+        return
       }
 
       if ('startViewTransition' in document) {
+        e.preventDefault()
+
         // @ts-ignore
         document.startViewTransition(
           () =>
             new Promise<void>((resolve) => {
               startTransition(() => {
-                navigate()
+                // copied from https://github.com/vercel/next.js/blob/66f8ffaa7a834f6591a12517618dce1fd69784f6/packages/next/src/client/link.tsx#L231-L233
+                router[replace ? 'replace' : 'push'](as || href, {
+                  scroll: scroll ?? true,
+                })
                 finishViewTransition(() => resolve)
               })
             })
         )
-
-        return
       }
-
-      startTransition(navigate)
     },
     [props.onClick, href, as, replace, scroll]
   )

--- a/src/link.tsx
+++ b/src/link.tsx
@@ -41,6 +41,7 @@ export function Link(props: React.ComponentProps<typeof NextLink>) {
   const router = useRouter()
   const finishViewTransition = useSetFinishViewTransition()
 
+  const { href, as, replace, scroll } = props
   const onClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>) => {
       if (shouldPreserveDefault(e)) {
@@ -55,7 +56,6 @@ export function Link(props: React.ComponentProps<typeof NextLink>) {
 
       // extended from https://github.com/vercel/next.js/blob/66f8ffaa7a834f6591a12517618dce1fd69784f6/packages/next/src/client/link.tsx#L221-L235
       // removed the need for pages router support
-      const { href, as, replace, scroll } = props
       const navigate = () => {
         router[replace ? 'replace' : 'push'](as || href, {
           scroll: scroll ?? true,
@@ -79,7 +79,7 @@ export function Link(props: React.ComponentProps<typeof NextLink>) {
 
       startTransition(navigate)
     },
-    [props.href, props.onClick]
+    [props.onClick, href, as, replace, scroll]
   )
 
   return <NextLink {...props} onClick={onClick} />

--- a/src/link.tsx
+++ b/src/link.tsx
@@ -48,11 +48,11 @@ export function Link(props: React.ComponentProps<typeof NextLink>) {
         props.onClick(e)
       }
 
-      if (shouldPreserveDefault(e)) {
-        return
-      }
-
       if ('startViewTransition' in document) {
+        if (shouldPreserveDefault(e)) {
+          return
+        }
+
         e.preventDefault()
 
         // @ts-ignore


### PR DESCRIPTION
Within `link.tsx`, a comment says "This is a wrapper around next/link", so I am assuming you would expect it to behave just like `next/link`.

The `onClick` function is missing a check for a modified event. The most common example is when `Ctrl`+`Click`ing a link, it opens the link in a new tab.

There is a `navigate()` function used in `next/link` that handles `replace`, `as`, and `scroll` that I extended to support only the app router, because this lib doesn't support the pages router.