### PR TITLE
Fix client-side exception

### DIFF
--- a/src/browser-native-events.ts
+++ b/src/browser-native-events.ts
@@ -1,75 +1,68 @@
-import { useEffect, useRef, useSyncExternalStore, use } from 'react'
+import { useEffect, useRef, use, useState } from 'react'
 import { usePathname } from 'next/navigation'
 
 // TODO: This implementation might not be complete when there are nested
 // Suspense boundaries during a route transition. But it should work fine for
 // the most common use cases.
 
-// This is a global variable to keep track of the view transition state.
-let currentViewTransition:
-  | null
-  | [
-      // Promise to wait for the view transition to start
-      Promise<void>,
-      // Resolver to finish the view transition
-      () => void
-    ] = null
-
 export function useBrowserNativeTransitions() {
   const pathname = usePathname()
   const currentPathname = useRef(pathname)
 
-  const transition = useSyncExternalStore(
-    (callback: () => void) => {
-      if (!('startViewTransition' in document)) {
-        return () => {}
-      }
+  // This is a global state to keep track of the view transition state.
+  const [currentViewTransition, setCurrentViewTransition] = useState<
+    | null
+    | [
+        // Promise to wait for the view transition to start
+        Promise<void>,
+        // Resolver to finish the view transition
+        () => void
+      ]
+  >(null)
 
-      const onPopState = () => {
-        let pendingViewTransitionResolve: () => void
+  useEffect(() => {
+    if (!('startViewTransition' in document)) {
+      return () => {}
+    }
 
-        const pendingViewTransition = new Promise<void>((resolve) => {
-          pendingViewTransitionResolve = resolve
+    const onPopState = () => {
+      let pendingViewTransitionResolve: () => void
+
+      const pendingViewTransition = new Promise<void>((resolve) => {
+        pendingViewTransitionResolve = resolve
+      })
+
+      const pendingStartViewTransition = new Promise<void>((resolve) => {
+        // @ts-ignore
+        document.startViewTransition(() => {
+          resolve()
+          return pendingViewTransition
         })
+      })
 
-        const pendingStartViewTransition = new Promise<void>((resolve) => {
-          // @ts-ignore
-          document.startViewTransition(() => {
-            resolve()
-            return pendingViewTransition
-          })
-        })
+      setCurrentViewTransition([
+        pendingStartViewTransition,
+        pendingViewTransitionResolve!,
+      ])
+    }
+    window.addEventListener('popstate', onPopState)
 
-        currentViewTransition = [
-          pendingStartViewTransition,
-          pendingViewTransitionResolve!,
-        ]
+    return () => {
+      window.removeEventListener('popstate', onPopState)
+    }
+  }, [])
 
-        callback()
-      }
-      window.addEventListener('popstate', onPopState)
-
-      return () => {
-        // TODO: Intentionally not cleaning up the event listener, otherwise the
-        // listener won't be registered again. This might be something related
-        // to the `use` call. We should investigate this further.
-      }
-    },
-    () => currentViewTransition,
-    () => null
-  )
-
-  if (transition && currentPathname.current !== pathname) {
+  if (currentViewTransition && currentPathname.current !== pathname) {
     // Whenever the pathname changes, we block the rendering of the new route
     // until the view transition is started (i.e. DOM screenshotted).
-    use(transition[0])
+    use(currentViewTransition[0])
   }
 
   // Keep the transition reference up-to-date.
-  const transitionRef = useRef(transition)
+  const transitionRef = useRef(currentViewTransition)
   useEffect(() => {
-    transitionRef.current = transition
-  }, [transition])
+    transitionRef.current = currentViewTransition
+  }, [currentViewTransition])
 
   useEffect(() => {
     // When the new route component is actually mounted, we finish the view


### PR DESCRIPTION
# Why
Fixes https://github.com/shuding/next-view-transitions/issues/7

[A previous PR](https://github.com/shuding/next-view-transitions/pull/8) tried to fix the client-side exception but broke the browser's back-forward animation.
This PR tries to solve the client-side exception while keeping the browser back-forward animation working.

# How


1. Rewrite the global `currentViewTransition` and usage of useSyncExternalStore to `useState` + `useEffect` combination.

2. Add a cleanup function inside `useEffect` to fix the client-side exception.

```typescript
window.removeEventListener('popstate', onPopState)
```

# Test Plan

The client-side error can be reproduced by navigating to another page via SPA, and then repeatedly moving back and forth fast.

I confirmed the following behaviors on this branch in the `example` app:
- the client-side error no longer occurs
- "Go to the Demo" Link navigation still animates
- The browser back-forward animation still works


https://github.com/shuding/next-view-transitions/assets/13040/6cceb484-6d48-4126-89aa-e4d793ca4570

