### PR TITLE
Fix: Page Freeze Issue When Using Back/Forward of Browser History with Query Parameter Only Changes

### DIFF
--- a/example/app/demo/page.js
+++ b/example/app/demo/page.js
@@ -1,24 +1,31 @@
 'use client'
 
-import { useTransitionRouter } from 'next-view-transitions'
+import { Link, useTransitionRouter } from 'next-view-transitions'
+import { useSearchParams } from 'next/navigation'
 
 export default function Page() {
   const router = useTransitionRouter()
+  const search = useSearchParams()
+
   return (
     <div className='demo-box'>
       <h2>
         This is the <span className='demo'>demo</span>
       </h2>
       <p>OK you just saw the demo :)</p>
-      <a
-        href='/'
-        onClick={(e) => {
-          e.preventDefault()
-          router.back()
-        }}
-      >
-        ← Back to homepage
-      </a>
+      <p>Current query params: {search}</p>
+      <div className='demo-link-box'>
+        <a
+          href='/'
+          onClick={(e) => {
+            e.preventDefault()
+            router.back()
+          }}
+        >
+          ← Back to homepage
+        </a>
+        <Link href='/demo?query=test2'>Test query param only change</Link>
+      </div>
     </div>
   )
 }

--- a/example/app/page.js
+++ b/example/app/page.js
@@ -27,6 +27,9 @@ export default function Page() {
           Go to /demo with custom transition →
         </a>
       </p>
+      <p>
+        <Link href='/demo?query=test'>Go to /demo with query parameters →</Link>
+      </p>
       <h2>Disclaimer</h2>
       <p>
         This library is aimed at basic use cases of View Transitions and Next.js

--- a/example/app/style.css
+++ b/example/app/style.css
@@ -136,6 +136,11 @@ footer {
   margin-top: 0;
 }
 
+.demo-link-box {
+  display: flex;
+  justify-content: space-between;
+}
+
 .support span {
   font-size: small;
   padding: 4px 6px;

--- a/src/browser-native-events.ts
+++ b/src/browser-native-events.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, use } from 'react'
-import { usePathname } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 
 // TODO: This implementation might not be complete when there are nested
 // Suspense boundaries during a route transition. But it should work fine for
@@ -64,6 +64,8 @@ export function useBrowserNativeTransitions() {
     transitionRef.current = currentViewTransition
   }, [currentViewTransition])
 
+  const search = useSearchParams()
+
   useEffect(() => {
     // When the new route component is actually mounted, we finish the view
     // transition.
@@ -72,5 +74,5 @@ export function useBrowserNativeTransitions() {
       transitionRef.current[1]()
       transitionRef.current = null
     }
-  }, [pathname])
+  }, [pathname, search])
 }


### PR DESCRIPTION
> Fix #16

I appreciate your effort in developing this awesome library.

By the way, it's pretty simillar change with #19. (it was related with hash, but mine is query params)
The page freezes (no interaction available) for a couple of seconds when i hit the `back` or `forward`,
where only the query parameters in the url are changed.

## To reproduce
1. Add any query parameter to where `ViewTransition` is applied.
2. NOT changing the pathname, change the query param only.
3. Change to the other query param.
4. hit the back and forward button of browser (it also stucks with `window.history.back()` / `.forward()` method.)

## Before fixing
https://github.com/user-attachments/assets/7bb561f9-74cf-43fe-bb1e-5784f93be6c1

## After fixing
https://github.com/user-attachments/assets/07d71f2f-fe18-4b98-bd9f-8ecd74141895

I'm looking forward to this pull request being merged.
Thanks.

P.S. Sorry for bad changes of demo page 😂 