### PR TITLE
fix: view transition also needs to be ended when the search parameters are changed

### DIFF
--- a/src/browser-native-events.ts
+++ b/src/browser-native-events.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, use } from 'react'
-import { usePathname } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 import { useHash } from './use-hash'
 
 // TODO: This implementation might not be complete when there are nested
@@ -8,6 +8,7 @@ import { useHash } from './use-hash'
 
 export function useBrowserNativeTransitions() {
   const pathname = usePathname()
+  const searchParams = useSearchParams()
   const currentPathname = useRef(pathname)
 
   // This is a global state to keep track of the view transition state.
@@ -75,5 +76,5 @@ export function useBrowserNativeTransitions() {
       transitionRef.current[1]()
       transitionRef.current = null
     }
-  }, [hash, pathname]);
+  }, [hash, pathname, searchParams]);
 }


### PR DESCRIPTION
Fixes: https://github.com/shuding/next-view-transitions/issues/47

## Description
With this change, navigating back from a URL with query parameters will no longer get stuck.

Before:

https://github.com/user-attachments/assets/1f2ff8b7-3e8f-49a8-a051-153836694d4d

After:

https://github.com/user-attachments/assets/c196582e-69ad-41b7-80f4-77402e206d9f

