### PR TITLE
Add prepare script to package.json to install a package from GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "exports": "./dist/index.js",
   "scripts": {
     "build": "bunchee",
-    "dev": "bunchee --watch"
+    "dev": "bunchee --watch",
+    "prepare": "npm run build"
   },
   "keywords": [
     "next",


### PR DESCRIPTION
This PR adds prepare script to package.json so that the library could be installed directly from GitHub via
```bash
npm install "git@github.com:shuding/next-view-transitions.git#main"
```
Currently this command installs a package without a build step.

I needed this to use the [fix](https://github.com/shuding/next-view-transitions/commit/6030a00941c01177076b1b4d107eb154c17c771a) for React 19 that is not available in the latest release v[0.3.4](https://github.com/shuding/next-view-transitions/releases/tag/0.3.4). It would also be great if you publish a new version to NPM.