### PR TITLE
Introduce useTransitionState hook for conditional view transition styling

### DIFF
--- a/src/browser-native-events.ts
+++ b/src/browser-native-events.ts
@@ -1,79 +1,93 @@
-import { useEffect, useRef, useState, use } from 'react'
+import { useEffect, useRef, useState, use, useContext } from 'react'
 import { usePathname } from 'next/navigation'
 import { useHash } from './use-hash'
+import { TransitionHrefContext } from './contexts'
 
-// TODO: This implementation might not be complete when there are nested
-// Suspense boundaries during a route transition. But it should work fine for
-// the most common use cases.
-
+/**
+ * Hook that implements browser native view transitions
+ * 
+ * This hooks into the browser's View Transition API to provide smooth
+ * transitions between route changes.
+ * 
+ * Note: This implementation might not be complete when there are nested
+ * Suspense boundaries during a route transition. But it should work fine for
+ * the most common use cases.
+ */
 export function useBrowserNativeTransitions() {
   const pathname = usePathname()
   const currentPathname = useRef(pathname)
-
-  // This is a global state to keep track of the view transition state.
-  const [currentViewTransition, setCurrentViewTransition] = useState<
-    | null
-    | [
-        // Promise to wait for the view transition to start
-        Promise<void>,
-        // Resolver to finish the view transition
-        () => void
-      ]
-  >(null)
-
+  const { setTransitioningHref } = useContext(TransitionHrefContext)
+  const hash = useHash()
+  
+  // Tuple type for view transition state: [startPromise, resolveFunction]
+  type ViewTransitionState = [Promise<void>, () => void] | null
+  
+  // Global state to track the current view transition
+  const [currentViewTransition, setCurrentViewTransition] = 
+    useState<ViewTransitionState>(null)
+  
+  // Keep a persistent reference to the transition state
+  const transitionRef = useRef(currentViewTransition)
+  
+  // Update the ref whenever the state changes
   useEffect(() => {
+    transitionRef.current = currentViewTransition
+  }, [currentViewTransition])
+  
+  // Set up popstate listener for navigation events
+  useEffect(() => {
+    // Skip if browser doesn't support View Transitions API
     if (!('startViewTransition' in document)) {
       return () => {}
     }
-
+    
     const onPopState = () => {
-      let pendingViewTransitionResolve: () => void
-
+      const newHref = window.location.pathname + window.location.hash
+      
+      // Set transitioning href early to ensure proper state tracking
+      setTransitioningHref(newHref)
+      
+      // Create a promise that will resolve when we're ready to complete the transition
+      let pendingViewTransitionResolve: () => void = () => {}
       const pendingViewTransition = new Promise<void>((resolve) => {
         pendingViewTransitionResolve = resolve
       })
-
+      
+      // Start the view transition and capture the DOM state
       const pendingStartViewTransition = new Promise<void>((resolve) => {
-        // @ts-ignore
+        // @ts-ignore - The View Transition API types might not be available
         document.startViewTransition(() => {
           resolve()
           return pendingViewTransition
         })
       })
-
+      
+      // Update state with promises needed to control the transition
       setCurrentViewTransition([
         pendingStartViewTransition,
-        pendingViewTransitionResolve!,
+        pendingViewTransitionResolve,
       ])
     }
+    
     window.addEventListener('popstate', onPopState)
-
     return () => {
       window.removeEventListener('popstate', onPopState)
     }
-  }, [])
-
+  }, [setTransitioningHref])
+  
+  // Block rendering until view transition starts
   if (currentViewTransition && currentPathname.current !== pathname) {
-    // Whenever the pathname changes, we block the rendering of the new route
-    // until the view transition is started (i.e. DOM screenshotted).
     use(currentViewTransition[0])
   }
-
-  // Keep the transition reference up-to-date.
-  const transitionRef = useRef(currentViewTransition)
+  
+  // Complete the transition when the new route is mounted
   useEffect(() => {
-    transitionRef.current = currentViewTransition
-  }, [currentViewTransition])
-
-  const hash = useHash();
-
-  useEffect(() => {
-    // When the new route component is actually mounted, we finish the view
-    // transition.
     currentPathname.current = pathname
+    
     if (transitionRef.current) {
       transitionRef.current[1]()
-      transitionRef.current = null
+      setCurrentViewTransition(null)
+      setTransitioningHref(null)
     }
-  }, [hash, pathname]);
+  }, [hash, pathname, setTransitioningHref])
 }

--- a/src/browser-native-events.ts
+++ b/src/browser-native-events.ts
@@ -3,40 +3,27 @@ import { usePathname } from 'next/navigation'
 import { useHash } from './use-hash'
 import { TransitionHrefContext } from './contexts'
 
-/**
- * Hook that implements browser native view transitions
- * 
- * This hooks into the browser's View Transition API to provide smooth
- * transitions between route changes.
- * 
- * Note: This implementation might not be complete when there are nested
- * Suspense boundaries during a route transition. But it should work fine for
- * the most common use cases.
- */
+// TODO: This implementation might not be complete when there are nested
+// Suspense boundaries during a route transition. But it should work fine for
+// the most common use cases.
+
 export function useBrowserNativeTransitions() {
   const pathname = usePathname()
   const currentPathname = useRef(pathname)
   const { setTransitioningHref } = useContext(TransitionHrefContext)
-  const hash = useHash()
   
-  // Tuple type for view transition state: [startPromise, resolveFunction]
-  type ViewTransitionState = [Promise<void>, () => void] | null
+   // This is a global state to keep track of the view transition state.
+  const [currentViewTransition, setCurrentViewTransition] = useState<
+  | null
+  | [
+      // Promise to wait for the view transition to start
+      Promise<void>,
+      // Resolver to finish the view transition
+      () => void
+    ]
+  >(null)
   
-  // Global state to track the current view transition
-  const [currentViewTransition, setCurrentViewTransition] = 
-    useState<ViewTransitionState>(null)
-  
-  // Keep a persistent reference to the transition state
-  const transitionRef = useRef(currentViewTransition)
-  
-  // Update the ref whenever the state changes
   useEffect(() => {
-    transitionRef.current = currentViewTransition
-  }, [currentViewTransition])
-  
-  // Set up popstate listener for navigation events
-  useEffect(() => {
-    // Skip if browser doesn't support View Transitions API
     if (!('startViewTransition' in document)) {
       return () => {}
     }
@@ -44,46 +31,52 @@ export function useBrowserNativeTransitions() {
     const onPopState = () => {
       const newHref = window.location.pathname + window.location.hash
       
-      // Set transitioning href early to ensure proper state tracking
       setTransitioningHref(newHref)
       
-      // Create a promise that will resolve when we're ready to complete the transition
       let pendingViewTransitionResolve: () => void = () => {}
+
       const pendingViewTransition = new Promise<void>((resolve) => {
         pendingViewTransitionResolve = resolve
       })
       
-      // Start the view transition and capture the DOM state
       const pendingStartViewTransition = new Promise<void>((resolve) => {
-        // @ts-ignore - The View Transition API types might not be available
+        // @ts-ignore
         document.startViewTransition(() => {
           resolve()
           return pendingViewTransition
         })
       })
       
-      // Update state with promises needed to control the transition
       setCurrentViewTransition([
         pendingStartViewTransition,
-        pendingViewTransitionResolve,
+        pendingViewTransitionResolve!,
       ])
     }
-    
     window.addEventListener('popstate', onPopState)
+
     return () => {
       window.removeEventListener('popstate', onPopState)
     }
   }, [setTransitioningHref])
   
-  // Block rendering until view transition starts
   if (currentViewTransition && currentPathname.current !== pathname) {
+    // Whenever the pathname changes, we block the rendering of the new route
+    // until the view transition is started (i.e. DOM screenshotted).
     use(currentViewTransition[0])
   }
-  
-  // Complete the transition when the new route is mounted
+
+  // Keep the transition reference up-to-date.
+  const transitionRef = useRef(currentViewTransition)
   useEffect(() => {
+    transitionRef.current = currentViewTransition
+  }, [currentViewTransition])
+
+  const hash = useHash()
+  
+  useEffect(() => {
+    // When the new route component is actually mounted, we finish the view
+    // transition.
     currentPathname.current = pathname
-    
     if (transitionRef.current) {
       transitionRef.current[1]()
       setCurrentViewTransition(null)

--- a/src/contexts.ts
+++ b/src/contexts.ts
@@ -1,18 +1,11 @@
 import { createContext } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 
-
-/**
- *Context for tracking the currently transitioning href
- */
 export interface TransitionHrefContextValue {
   transitioningHref: string | null
   setTransitioningHref: (href: string | null) => void
 }
 
-/**
- * Context for managing view transition completion callbacks
- */
 export const ViewTransitionsContext = createContext<
   Dispatch<SetStateAction<(() => void) | null>>
 >(() => {})

--- a/src/contexts.ts
+++ b/src/contexts.ts
@@ -1,0 +1,23 @@
+import { createContext } from 'react'
+import type { Dispatch, SetStateAction } from 'react'
+
+
+/**
+ *Context for tracking the currently transitioning href
+ */
+export interface TransitionHrefContextValue {
+  transitioningHref: string | null
+  setTransitioningHref: (href: string | null) => void
+}
+
+/**
+ * Context for managing view transition completion callbacks
+ */
+export const ViewTransitionsContext = createContext<
+  Dispatch<SetStateAction<(() => void) | null>>
+>(() => {})
+
+export const TransitionHrefContext = createContext<TransitionHrefContextValue>({
+  transitioningHref: null,
+  setTransitioningHref: () => {}
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 'use client'
 
 export { Link } from './link'
-export { ViewTransitions } from './transition-context'
+export { ViewTransitions, useTransitionState } from './transition-context'
 export { useTransitionRouter } from './use-transition-router'

--- a/src/link.tsx
+++ b/src/link.tsx
@@ -2,12 +2,7 @@ import NextLink from 'next/link'
 import { useTransitionRouter } from './use-transition-router'
 import { useCallback } from 'react'
 
-/**
- * Determines if a click event was modified (e.g., with meta key or ctrl key)
- * 
- * @param event - The mouse event to check
- * @returns Whether the event was modified
- */
+// copied from https://github.com/vercel/next.js/blob/66f8ffaa7a834f6591a12517618dce1fd69784f6/packages/next/src/client/link.tsx#L180-L191
 function isModifiedEvent(event: React.MouseEvent): boolean {
   const eventTarget = event.currentTarget as HTMLAnchorElement | SVGAElement
   const target = eventTarget.getAttribute('target')
@@ -21,55 +16,49 @@ function isModifiedEvent(event: React.MouseEvent): boolean {
   )
 }
 
-/**
- * Determines if the browser's default behavior should be preserved for a click event
- * 
- * @param e - The mouse event to check
- * @returns Whether the default behavior should be preserved
- */
-function shouldPreserveDefault(e: React.MouseEvent<HTMLAnchorElement>): boolean {
+// copied from https://github.com/vercel/next.js/blob/66f8ffaa7a834f6591a12517618dce1fd69784f6/packages/next/src/client/link.tsx#L204-L217
+function shouldPreserveDefault(
+  e: React.MouseEvent<HTMLAnchorElement>
+): boolean {
   const { nodeName } = e.currentTarget
 
   // anchors inside an svg have a lowercase nodeName
   const isAnchorNodeName = nodeName.toUpperCase() === 'A'
 
-  return isAnchorNodeName && isModifiedEvent(e)
+  if (isAnchorNodeName && isModifiedEvent(e)) {
+    // ignore click for browser’s default behavior
+    return true
+  }
+
+  return false
 }
 
-/**
- * Extended Link component that supports view transitions
- * 
- * This component wraps Next.js Link and adds support for the View Transitions API
- * when navigating between pages.
- */
+// This is a wrapper around next/link that explicitly uses the router APIs
+// to navigate, and trigger a view transition.
+
 export function Link(props: React.ComponentProps<typeof NextLink>) {
   const router = useTransitionRouter()
-  const { href, as, replace, scroll, onClick: userOnClick, ...restProps } = props
 
+  const { href, as, replace, scroll } = props
   const onClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>) => {
-      // Call the user's onClick handler if provided
-      if (userOnClick) {
-        userOnClick(e)
+      if (props.onClick) {
+        props.onClick(e)
       }
 
-      // Only use view transitions if the browser supports it
       if ('startViewTransition' in document) {
-        // Don't override default behavior for modified clicks
         if (shouldPreserveDefault(e)) {
           return
         }
 
-        // Prevent default behavior to handle navigation ourselves
         e.preventDefault()
 
-        // Use the appropriate navigation method based on the replace prop
         const navigate = replace ? router.replace : router.push
         navigate(as || href, { scroll: scroll ?? true })
       }
     },
-    [userOnClick, href, as, replace, scroll, router]
+    [props.onClick, href, as, replace, scroll]
   )
 
-  return <NextLink {...restProps} href={href} as={as} replace={replace} scroll={scroll} onClick={onClick} />
+  return <NextLink {...props} onClick={onClick} />
 }

--- a/src/transition-context.tsx
+++ b/src/transition-context.tsx
@@ -2,23 +2,17 @@ import { use, useContext, useEffect, useState } from 'react'
 import { useBrowserNativeTransitions } from './browser-native-events'
 import { ViewTransitionsContext, TransitionHrefContext } from './contexts'
 
-/**
- * Internal component that initializes browser native transition handlers
- */
 function BrowserNativeTransitions({ children }: Readonly<{ children: React.ReactNode }>) {
   useBrowserNativeTransitions()
   return children
 }
-/**
- * Provider component that manages view transitions state
- */
+
 export function ViewTransitions({ children }: Readonly<{
   children: React.ReactNode
 }>) {
   const [finishViewTransition, setFinishViewTransition] = useState<null | (() => void)>(null)
   const [transitioningHref, setTransitioningHref] = useState<string | null>(null)
 
-  // Execute and clear transition completion callback when available
   useEffect(() => {
     if (!finishViewTransition) return
     finishViewTransition()
@@ -37,19 +31,10 @@ export function ViewTransitions({ children }: Readonly<{
   )
 }
 
-/**
- * Hook to access the function for completing view transitions
- */
 export function useSetFinishViewTransition() {
   return use(ViewTransitionsContext)
 }
 
-/**
- * Hook to determine if a specific URL is currently transitioning
- * 
- * @param href - The URL to check
- * @returns True if this URL is currently in transition
- */
 export function useTransitionState(href: string): boolean {
   const { transitioningHref } = useContext(TransitionHrefContext)
   return transitioningHref === href

--- a/src/transition-context.tsx
+++ b/src/transition-context.tsx
@@ -1,37 +1,56 @@
-import type { Dispatch, SetStateAction } from 'react'
-import { createContext, use, useEffect, useState } from 'react'
-
+import { use, useContext, useEffect, useState } from 'react'
 import { useBrowserNativeTransitions } from './browser-native-events'
+import { ViewTransitionsContext, TransitionHrefContext } from './contexts'
 
-const ViewTransitionsContext = createContext<
-  Dispatch<SetStateAction<(() => void) | null>>
->(() => () => {})
-
-export function ViewTransitions({
-  children,
-}: Readonly<{
+/**
+ * Internal component that initializes browser native transition handlers
+ */
+function BrowserNativeTransitions({ children }: Readonly<{ children: React.ReactNode }>) {
+  useBrowserNativeTransitions()
+  return children
+}
+/**
+ * Provider component that manages view transitions state
+ */
+export function ViewTransitions({ children }: Readonly<{
   children: React.ReactNode
 }>) {
-  const [finishViewTransition, setFinishViewTransition] = useState<
-    null | (() => void)
-  >(null)
+  const [finishViewTransition, setFinishViewTransition] = useState<null | (() => void)>(null)
+  const [transitioningHref, setTransitioningHref] = useState<string | null>(null)
 
+  // Execute and clear transition completion callback when available
   useEffect(() => {
-    if (finishViewTransition) {
-      finishViewTransition()
-      setFinishViewTransition(null)
-    }
+    if (!finishViewTransition) return
+    finishViewTransition()
+    setFinishViewTransition(null)
   }, [finishViewTransition])
 
-  useBrowserNativeTransitions()
 
   return (
     <ViewTransitionsContext.Provider value={setFinishViewTransition}>
-      {children}
+      <TransitionHrefContext.Provider value={{ transitioningHref, setTransitioningHref }}>
+        <BrowserNativeTransitions>
+          {children}
+        </BrowserNativeTransitions>
+      </TransitionHrefContext.Provider>
     </ViewTransitionsContext.Provider>
   )
 }
 
+/**
+ * Hook to access the function for completing view transitions
+ */
 export function useSetFinishViewTransition() {
   return use(ViewTransitionsContext)
+}
+
+/**
+ * Hook to determine if a specific URL is currently transitioning
+ * 
+ * @param href - The URL to check
+ * @returns True if this URL is currently in transition
+ */
+export function useTransitionState(href: string): boolean {
+  const { transitioningHref } = useContext(TransitionHrefContext)
+  return transitioningHref === href
 }

--- a/src/use-hash.ts
+++ b/src/use-hash.ts
@@ -1,6 +1,14 @@
 import { useSyncExternalStore } from 'react'
 
-export function useHash() {
+/**
+ * Hook to subscribe to URL hash changes
+ * 
+ * This hook provides a reactive way to access the current URL hash,
+ * automatically re-rendering components when the hash changes.
+ * 
+ * @returns The current URL hash string
+ */
+export function useHash(): string {
   return useSyncExternalStore(
     subscribeHash,
     getHashSnapshot,
@@ -8,15 +16,31 @@ export function useHash() {
   )
 }
 
-function getHashSnapshot() {
+/**
+ * Get the current hash value from the browser
+ * 
+ * @returns The current URL hash string
+ */
+function getHashSnapshot(): string {
   return window.location.hash
 }
 
-function getServerHashSnapshot() {
+/**
+ * Provide a default hash value for server-side rendering
+ * 
+ * @returns Empty string as hash is not available on the server
+ */
+function getServerHashSnapshot(): string {
   return ''
 }
 
-function subscribeHash(onStoreChange: () => void) {
+/**
+ * Subscribe to hash change events
+ * 
+ * @param onStoreChange - Callback function to execute when hash changes
+ * @returns Cleanup function to remove the event listener
+ */
+function subscribeHash(onStoreChange: () => void): () => void {
   window.addEventListener('hashchange', onStoreChange)
   return () => window.removeEventListener('hashchange', onStoreChange)
 }

--- a/src/use-hash.ts
+++ b/src/use-hash.ts
@@ -1,14 +1,6 @@
 import { useSyncExternalStore } from 'react'
 
-/**
- * Hook to subscribe to URL hash changes
- * 
- * This hook provides a reactive way to access the current URL hash,
- * automatically re-rendering components when the hash changes.
- * 
- * @returns The current URL hash string
- */
-export function useHash(): string {
+export function useHash() {
   return useSyncExternalStore(
     subscribeHash,
     getHashSnapshot,
@@ -16,31 +8,15 @@ export function useHash(): string {
   )
 }
 
-/**
- * Get the current hash value from the browser
- * 
- * @returns The current URL hash string
- */
-function getHashSnapshot(): string {
+function getHashSnapshot() {
   return window.location.hash
 }
 
-/**
- * Provide a default hash value for server-side rendering
- * 
- * @returns Empty string as hash is not available on the server
- */
-function getServerHashSnapshot(): string {
+function getServerHashSnapshot() {
   return ''
 }
 
-/**
- * Subscribe to hash change events
- * 
- * @param onStoreChange - Callback function to execute when hash changes
- * @returns Cleanup function to remove the event listener
- */
-function subscribeHash(onStoreChange: () => void): () => void {
+function subscribeHash(onStoreChange: () => void) {
   window.addEventListener('hashchange', onStoreChange)
   return () => window.removeEventListener('hashchange', onStoreChange)
 }

--- a/src/use-transition-router.ts
+++ b/src/use-transition-router.ts
@@ -7,93 +7,55 @@ import {
 } from "next/dist/shared/lib/app-router-context.shared-runtime"
 import { useSetFinishViewTransition } from './transition-context'
 
-/**
- * Additional options for transitions
- */
+
 export type TransitionOptions = {
-  /**
-   * Callback fired when the transition is ready (DOM has been captured)
-   */
   onTransitionReady?: () => void
 }
 
-/**
- * Combined navigation options with transition-specific options
- */
 type NavigateOptionsWithTransition = NavigateOptions & TransitionOptions
 
-/**
- * Extended router interface with transition-aware navigation methods
- */
 export type TransitionRouter = AppRouterInstance & {
-  /**
-   * Push a new URL with view transition support
-   */
   push: (href: string, options?: NavigateOptionsWithTransition) => void
-  /**
-   * Replace current URL with view transition support
-   */
   replace: (href: string, options?: NavigateOptionsWithTransition) => void
 }
 
-/**
- * Hook that provides a router enhanced with view transition capabilities
- * 
- * @returns A router instance with transition-aware navigation methods
- */
 export function useTransitionRouter(): TransitionRouter {
   const router = useNextRouter()
   const finishViewTransition = useSetFinishViewTransition()
   const { setTransitioningHref } = useContext(TransitionHrefContext)
 
-  /**
-   * Trigger a view transition for a navigation action
-   * 
-   * @param href - The URL to navigate to
-   * @param cb - The navigation callback to execute
-   * @param options - Additional transition options
-   */
   const triggerTransition = useCallback((
     href: string, 
     cb: () => void, 
     { onTransitionReady }: TransitionOptions = {}
   ) => {
-    // Set the href being transitioned to for tracking
     setTransitioningHref(href)
 
-    // Use View Transitions API if supported
     if ('startViewTransition' in document) {
-      // @ts-ignore - View Transitions API may not be typed
+      // @ts-ignore
       const transition = document.startViewTransition(() => 
         new Promise<void>((resolve) => {
           startTransition(() => {
-            // Execute the navigation
             cb()
-            // Signal when the transition can finish
             finishViewTransition(() => resolve)
           })
         })
       )
 
-      // Clean up when the transition is complete
       transition.finished.finally(() => {
         setTransitioningHref(null)
       })
 
-      // Call the ready callback if provided
       if (onTransitionReady) {
         transition.ready.then(onTransitionReady)
       }
     } else {
-      // Fallback for browsers without View Transitions support
       setTransitioningHref(null)
       return cb()
     }
   }, [setTransitioningHref, finishViewTransition])
 
-  /**
-   * Enhanced push navigation with view transition support
-   */
+ 
   const push = useCallback(
     (href: string, { onTransitionReady, ...options }: NavigateOptionsWithTransition = {}) => {
       triggerTransition(href, () => router.push(href, options), { onTransitionReady })
@@ -101,9 +63,6 @@ export function useTransitionRouter(): TransitionRouter {
     [triggerTransition, router]
   )
 
-  /**
-   * Enhanced replace navigation with view transition support
-   */
   const replace = useCallback(
     (href: string, { onTransitionReady, ...options }: NavigateOptionsWithTransition = {}) => {
       triggerTransition(href, () => router.replace(href, options), { onTransitionReady })

--- a/src/use-transition-router.ts
+++ b/src/use-transition-router.ts
@@ -1,65 +1,115 @@
 import { useRouter as useNextRouter } from 'next/navigation'
-import {startTransition, useCallback, useMemo} from "react";
-import { useSetFinishViewTransition } from "./transition-context";
+import { startTransition, useCallback, useContext, useMemo } from "react"
+import { TransitionHrefContext } from "./contexts"
 import {
   AppRouterInstance,
   NavigateOptions
-} from "next/dist/shared/lib/app-router-context.shared-runtime";
+} from "next/dist/shared/lib/app-router-context.shared-runtime"
+import { useSetFinishViewTransition } from './transition-context'
 
+/**
+ * Additional options for transitions
+ */
 export type TransitionOptions = {
-  onTransitionReady?: () => void;
-};
+  /**
+   * Callback fired when the transition is ready (DOM has been captured)
+   */
+  onTransitionReady?: () => void
+}
 
-type NavigateOptionsWithTransition = NavigateOptions & TransitionOptions;
+/**
+ * Combined navigation options with transition-specific options
+ */
+type NavigateOptionsWithTransition = NavigateOptions & TransitionOptions
 
+/**
+ * Extended router interface with transition-aware navigation methods
+ */
 export type TransitionRouter = AppRouterInstance & {
-  push: (href: string, options?: NavigateOptionsWithTransition) => void;
-  replace: (href: string, options?: NavigateOptionsWithTransition) => void;
-};
+  /**
+   * Push a new URL with view transition support
+   */
+  push: (href: string, options?: NavigateOptionsWithTransition) => void
+  /**
+   * Replace current URL with view transition support
+   */
+  replace: (href: string, options?: NavigateOptionsWithTransition) => void
+}
 
-export function useTransitionRouter() {
+/**
+ * Hook that provides a router enhanced with view transition capabilities
+ * 
+ * @returns A router instance with transition-aware navigation methods
+ */
+export function useTransitionRouter(): TransitionRouter {
   const router = useNextRouter()
   const finishViewTransition = useSetFinishViewTransition()
+  const { setTransitioningHref } = useContext(TransitionHrefContext)
 
-  const triggerTransition = useCallback((cb: () => void, { onTransitionReady }: TransitionOptions = {}) => {
+  /**
+   * Trigger a view transition for a navigation action
+   * 
+   * @param href - The URL to navigate to
+   * @param cb - The navigation callback to execute
+   * @param options - Additional transition options
+   */
+  const triggerTransition = useCallback((
+    href: string, 
+    cb: () => void, 
+    { onTransitionReady }: TransitionOptions = {}
+  ) => {
+    // Set the href being transitioned to for tracking
+    setTransitioningHref(href)
+
+    // Use View Transitions API if supported
     if ('startViewTransition' in document) {
-      // @ts-ignore
-      const transition = document.startViewTransition(
-        () =>
-          new Promise<void>((resolve) => {
-            startTransition(() => {
-              cb();
-              finishViewTransition(() => resolve)
-            })
+      // @ts-ignore - View Transitions API may not be typed
+      const transition = document.startViewTransition(() => 
+        new Promise<void>((resolve) => {
+          startTransition(() => {
+            // Execute the navigation
+            cb()
+            // Signal when the transition can finish
+            finishViewTransition(() => resolve)
           })
+        })
       )
 
-        if (onTransitionReady) {
-          transition.ready.then(onTransitionReady);
-        }
-    }
-     else {
-        return cb()
+      // Clean up when the transition is complete
+      transition.finished.finally(() => {
+        setTransitioningHref(null)
+      })
+
+      // Call the ready callback if provided
+      if (onTransitionReady) {
+        transition.ready.then(onTransitionReady)
       }
-  }, [])
+    } else {
+      // Fallback for browsers without View Transitions support
+      setTransitioningHref(null)
+      return cb()
+    }
+  }, [setTransitioningHref, finishViewTransition])
 
-  const push = useCallback((
-    href: string,
-    { onTransitionReady, ...options }: NavigateOptionsWithTransition = {}
-  ) => {
-    triggerTransition(() => router.push(href, options), {
-      onTransitionReady
-    })
-  }, [triggerTransition, router])
+  /**
+   * Enhanced push navigation with view transition support
+   */
+  const push = useCallback(
+    (href: string, { onTransitionReady, ...options }: NavigateOptionsWithTransition = {}) => {
+      triggerTransition(href, () => router.push(href, options), { onTransitionReady })
+    },
+    [triggerTransition, router]
+  )
 
-  const replace = useCallback((
-    href: string,
-    { onTransitionReady, ...options }: NavigateOptionsWithTransition = {}
-  ) => {
-    triggerTransition(() => router.replace(href, options), {
-      onTransitionReady
-    });
-  }, [triggerTransition, router]);
+  /**
+   * Enhanced replace navigation with view transition support
+   */
+  const replace = useCallback(
+    (href: string, { onTransitionReady, ...options }: NavigateOptionsWithTransition = {}) => {
+      triggerTransition(href, () => router.replace(href, options), { onTransitionReady })
+    },
+    [triggerTransition, router]
+  )
 
   return useMemo<TransitionRouter>(
     () => ({
@@ -67,5 +117,6 @@ export function useTransitionRouter() {
       push,
       replace,
     }),
-    [push, replace, router]);
+    [push, replace, router]
+  )
 }


### PR DESCRIPTION
This PR adds an initial implementation for a `useTransitionState` hook, enabling developers to apply view transition names conditionally based on active navigation states.

### Changes:
- Exports `useTransitionState` hook to check if a transition to a specific `href` is active

- Tracks transitioning URLs via context to support conditional styling

- Updates transition handling to synchronize state with routing

### Usage Example:
Use `useTransitionState` to dynamically apply a `viewTransitionName` during navigation:

```tsx
import { useTransitionState, Link } from 'next-view-transitions';

function NavigationItem({ href, label }) {
  const isTransitioning = useTransitionState(href);
  
  return (
    <li
      style={{
        viewTransitionName: isTransitioning ? 'nav-item-transition' : '',
      }}
    >
      <Link href={href}>{label}</Link>
    </li>
  );
}
```
### Behavior:

- When navigating to `href`, the `viewTransitionName` "nav-item-transition" is applied to the `<li>`

- The transition name is removed once the navigation completes

- Enables targeted animations for smoother page transitions

This enhancement allows granular control over view transitions, improving user experience during route changes.