### PR TITLE
perf: avoid sluggish route transitions by adding early context check

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "bunchee",
     "dev": "bunchee --watch",
-    "prepare": "npm run build"
+    "prepare": "pnpm run build"
   },
   "keywords": [
     "next",

--- a/src/transition-context.tsx
+++ b/src/transition-context.tsx
@@ -5,7 +5,7 @@ import { useBrowserNativeTransitions } from './browser-native-events'
 
 const ViewTransitionsContext = createContext<
   Dispatch<SetStateAction<(() => void) | null>>
->(() => () => {})
+>(null)
 
 export function ViewTransitions({
   children,
@@ -33,5 +33,13 @@ export function ViewTransitions({
 }
 
 export function useSetFinishViewTransition() {
-  return use(ViewTransitionsContext)
+  const context = use(ViewTransitionsContext)
+
+  if (!context) {
+    throw new Error(
+      'useSetFinishViewTransition must be used within a ViewTransitions component',
+    )
+  }
+
+  return context
 }


### PR DESCRIPTION
Page switching becomes noticeably slow (and no transitions) when the required context provider is missing.


https://github.com/user-attachments/assets/cdb25992-d47e-4fa7-b923-0da09a75d435

