### PR TITLE
fix: add opt-in scroll restoration for view transitions

### DIFF
--- a/src/browser-native-events.ts
+++ b/src/browser-native-events.ts
@@ -1,12 +1,25 @@
 import { useEffect, useRef, useState, use } from 'react'
 import { usePathname } from 'next/navigation'
 import { useHash } from './use-hash'
+import type { ViewTransitionsOptions } from './transition-context'
 
 // TODO: This implementation might not be complete when there are nested
 // Suspense boundaries during a route transition. But it should work fine for
 // the most common use cases.
 
-export function useBrowserNativeTransitions() {
+type BrowserNativeTransitionsOptions = Pick<ViewTransitionsOptions, 'scroll'>
+
+const SCROLL_STATE_KEY = '__nvt_scroll'
+
+/** Persists the current scroll offset into the active history entry. */
+function saveScrollPosition() {
+  history.replaceState(
+    { ...history.state, [SCROLL_STATE_KEY]: { x: window.scrollX, y: window.scrollY } },
+    ''
+  )
+}
+
+export function useBrowserNativeTransitions({ scroll }: BrowserNativeTransitionsOptions = {}) {
   const pathname = usePathname()
   const currentPathname = useRef(pathname)
 
@@ -17,7 +30,9 @@ export function useBrowserNativeTransitions() {
         // Promise to wait for the view transition to start
         Promise<void>,
         // Resolver to finish the view transition
-        () => void
+        () => void,
+        // Saved scroll position to restore after transition
+        { x: number; y: number } | null
       ]
   >(null)
 
@@ -26,7 +41,20 @@ export function useBrowserNativeTransitions() {
       return () => {}
     }
 
+    let scrollTimer: ReturnType<typeof setTimeout>
+    const onScroll = () => {
+      clearTimeout(scrollTimer)
+      scrollTimer = setTimeout(saveScrollPosition, 100)
+    }
+    if (scroll) {
+      window.addEventListener('scroll', onScroll, { passive: true })
+    }
+
     const onPopState = () => {
+      const savedPosition = scroll
+        ? history.state?.[SCROLL_STATE_KEY] ?? null
+        : null
+
       let pendingViewTransitionResolve: () => void
 
       const pendingViewTransition = new Promise<void>((resolve) => {
@@ -44,12 +72,15 @@ export function useBrowserNativeTransitions() {
       setCurrentViewTransition([
         pendingStartViewTransition,
         pendingViewTransitionResolve!,
+        savedPosition,
       ])
     }
     window.addEventListener('popstate', onPopState)
 
     return () => {
       window.removeEventListener('popstate', onPopState)
+      window.removeEventListener('scroll', onScroll)
+      clearTimeout(scrollTimer)
     }
   }, [])
 
@@ -72,6 +103,11 @@ export function useBrowserNativeTransitions() {
     // transition.
     currentPathname.current = pathname
     if (transitionRef.current) {
+      const savedPosition = transitionRef.current[2]
+      if (savedPosition) {
+        window.scrollTo(savedPosition.x, savedPosition.y)
+      }
+
       transitionRef.current[1]()
       transitionRef.current = null
     }

--- a/src/transition-context.tsx
+++ b/src/transition-context.tsx
@@ -3,14 +3,20 @@ import { createContext, use, useEffect, useState } from 'react'
 
 import { useBrowserNativeTransitions } from './browser-native-events'
 
+export type ViewTransitionsOptions = {
+  scroll?: boolean
+}
+
 const ViewTransitionsContext = createContext<
   Dispatch<SetStateAction<(() => void) | null>>
 >(null)
 
 export function ViewTransitions({
   children,
+  options,
 }: Readonly<{
   children: React.ReactNode
+  options?: ViewTransitionsOptions
 }>) {
   const [finishViewTransition, setFinishViewTransition] = useState<
     null | (() => void)
@@ -23,7 +29,7 @@ export function ViewTransitions({
     }
   }, [finishViewTransition])
 
-  useBrowserNativeTransitions()
+  useBrowserNativeTransitions({ scroll: options?.scroll })
 
   return (
     <ViewTransitionsContext.Provider value={setFinishViewTransition}>


### PR DESCRIPTION
## Problem

When `<ViewTransitions>` wraps a Next.js app, scroll restoration stops working. Navigating to a page and pressing back always scrolls to the top.

**Root cause**: The `popstate` handler in `browser-native-events.ts` wraps navigation in `document.startViewTransition()`, which defers DOM updates and prevents the browser's/Next.js's scroll restoration from working.

## Solution

Adds opt-in scroll restoration via the `options` prop:

```tsx
<ViewTransitions options={{ scroll: true }}>
  {children}
</ViewTransitions>
```

When enabled:
1. Scroll positions are persisted into `history.state` via `replaceState` (debounced at 100ms)
2. On `popstate`, the saved position is read from the target history entry
3. Scroll is restored **before** the view transition resolves, so the new DOM snapshot captures the correct position

This follows the same pattern used by Remix and React Router — positions are stored in `history.state`.

## Changes

- **`browser-native-events.ts`**: Added `saveScrollPosition` helper, debounced scroll listener, and scroll restore before transition resolve
- **`transition-context.tsx`**: Added `ViewTransitionsOptions` type and `options` prop to `ViewTransitions` component

## Breaking Changes

None. Scroll restoration is opt-in and disabled by default.

Fixes #58
Fixes #12