### PR TITLE
Handle exception from Safari implementation

### DIFF
--- a/src/browser-native-events.ts
+++ b/src/browser-native-events.ts
@@ -38,7 +38,7 @@ export function useBrowserNativeTransitions() {
         document.startViewTransition(() => {
           resolve()
           return pendingViewTransition
-        })
+        }).catch(() => {})
       })
 
       setCurrentViewTransition([

--- a/src/use-transition-router.ts
+++ b/src/use-transition-router.ts
@@ -34,9 +34,11 @@ export function useTransitionRouter() {
           })
       )
 
+        let promise = transition.ready;
         if (onTransitionReady) {
-          transition.ready.then(onTransitionReady);
+          promise = promise.then(onTransitionReady);
         }
+        promise.catch(() => {});
     }
      else {
         return cb()


### PR DESCRIPTION
Safari's behavior is different when a transition is already in progress. It raises an exception and aborts the first transition, while other browsers silently ignore calls.

https://github.com/angular/angular/issues/62491